### PR TITLE
Add Tailwind CSS configuration

### DIFF
--- a/f1-predictor-full/tailwind.config.js
+++ b/f1-predictor-full/tailwind.config.js
@@ -1,0 +1,44 @@
+const defaultTheme = require('tailwindcss/defaultTheme');
+const plugin = require('tailwindcss/plugin');
+
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./styles/**/*.{css,scss,sass}"
+  ],
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          DEFAULT: "#E10600",
+          foreground: "#FFFFFF"
+        },
+        asphalt: {
+          DEFAULT: "#1F1F1F",
+          foreground: "#F5F5F5"
+        }
+      },
+      fontFamily: {
+        sans: ["Inter", ...defaultTheme.fontFamily.sans],
+        display: ["Rajdhani", ...defaultTheme.fontFamily.sans]
+      },
+      boxShadow: {
+        pitlane: "0 12px 50px -15px rgba(225, 6, 0, 0.5)"
+      }
+    }
+  },
+  plugins: [
+    plugin(function ({ addUtilities }) {
+      addUtilities({
+        ".text-shadow": {
+          "text-shadow": "0 2px 12px rgba(0, 0, 0, 0.35)"
+        },
+        ".text-shadow-none": {
+          "text-shadow": "none"
+        }
+      });
+    })
+  ]
+};


### PR DESCRIPTION
## Summary
- add a Tailwind CSS configuration at the project root
- configure content scanning for the app, components, and styles directories
- extend the theme with custom colours, fonts, and shadows plus a bespoke text-shadow utility plugin

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c959b12370832bbb7f17af80a3e6bd