### PR TITLE
Replace escaped newlines with actual line breaks

### DIFF
--- a/f1-predictor-full/app/layout.tsx
+++ b/f1-predictor-full/app/layout.tsx
@@ -1,1 +1,11 @@
-export default function RootLayout({ children }: { children: React.ReactNode }) {\n  return (\n    <html lang=\"en\">\n      <body className=\"bg-dark text-white min-h-screen\">{children}</body>\n    </html>\n  );\n}\n
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body className="bg-dark text-white min-h-screen">{children}</body>
+    </html>
+  );
+}

--- a/f1-predictor-full/app/page.tsx
+++ b/f1-predictor-full/app/page.tsx
@@ -1,1 +1,4 @@
-import { redirect } from 'next/navigation';\nexport default function Home() { redirect('/dashboard'); }\n
+import { redirect } from "next/navigation";
+export default function Home() {
+  redirect("/dashboard");
+}

--- a/f1-predictor-full/components/Navbar.tsx
+++ b/f1-predictor-full/components/Navbar.tsx
@@ -1,1 +1,15 @@
-import Link from 'next/link';\nexport default function Navbar(){return(<nav className='flex gap-4 p-4 bg-primary font-bold'><Link href='/dashboard'>Dashboard</Link><Link href='/drivers'>Pilotos</Link><Link href='/teams'>Equipas</Link><Link href='/tracks'>Pistas</Link><Link href='/simulations'>Simulações</Link><Link href='/data'>Dados</Link><Link href='/analysis'>Análises</Link><Link href='/settings'>Configurações</Link></nav>);}
+import Link from "next/link";
+export default function Navbar() {
+  return (
+    <nav className="flex gap-4 p-4 bg-primary font-bold">
+      <Link href="/dashboard">Dashboard</Link>
+      <Link href="/drivers">Pilotos</Link>
+      <Link href="/teams">Equipas</Link>
+      <Link href="/tracks">Pistas</Link>
+      <Link href="/simulations">Simulações</Link>
+      <Link href="/data">Dados</Link>
+      <Link href="/analysis">Análises</Link>
+      <Link href="/settings">Configurações</Link>
+    </nav>
+  );
+}

--- a/f1-predictor-full/styles/globals.css
+++ b/f1-predictor-full/styles/globals.css
@@ -1,1 +1,7 @@
-@tailwind base;\n@tailwind components;\n@tailwind utilities;\n\nbody { font-family: sans-serif; }\n
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  font-family: sans-serif;
+}


### PR DESCRIPTION
## Summary
- replace escaped newline sequences with actual newlines in the navbar, root layout, and home page files
- reformat the affected TypeScript and CSS files using Prettier to restore standard JSX and Tailwind formatting

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c959244b94832bbf385c9db03e13fe