### PR TITLE
Add Vitest configuration with initial store and Navbar tests

### DIFF
--- a/f1-predictor-full/components/Navbar.tsx
+++ b/f1-predictor-full/components/Navbar.tsx
@@ -1,1 +1,25 @@
-import Link from 'next/link';\nexport default function Navbar(){return(<nav className='flex gap-4 p-4 bg-primary font-bold'><Link href='/dashboard'>Dashboard</Link><Link href='/drivers'>Pilotos</Link><Link href='/teams'>Equipas</Link><Link href='/tracks'>Pistas</Link><Link href='/simulations'>Simulações</Link><Link href='/data'>Dados</Link><Link href='/analysis'>Análises</Link><Link href='/settings'>Configurações</Link></nav>);}
+import React from 'react';
+import Link from 'next/link';
+
+const links = [
+  { href: '/dashboard', label: 'Dashboard' },
+  { href: '/drivers', label: 'Pilotos' },
+  { href: '/teams', label: 'Equipas' },
+  { href: '/tracks', label: 'Pistas' },
+  { href: '/simulations', label: 'Simulações' },
+  { href: '/data', label: 'Dados' },
+  { href: '/analysis', label: 'Análises' },
+  { href: '/settings', label: 'Configurações' },
+];
+
+export default function Navbar() {
+  return (
+    <nav className="flex gap-4 p-4 bg-primary font-bold">
+      {links.map((link) => (
+        <Link key={link.href} href={link.href}>
+          {link.label}
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/f1-predictor-full/tests/navbar.test.tsx
+++ b/f1-predictor-full/tests/navbar.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import Navbar from '../components/Navbar';
+
+describe('Navbar', () => {
+  it('renders navigation links for the main sections', () => {
+    render(<Navbar />);
+
+    const navigation = screen.getByRole('navigation');
+    const links = within(navigation).getAllByRole('link');
+
+    expect(links).toHaveLength(8);
+    expect(screen.getByRole('link', { name: 'Dashboard' })).toHaveAttribute('href', '/dashboard');
+    expect(screen.getByRole('link', { name: 'Pilotos' })).toHaveAttribute('href', '/drivers');
+    expect(screen.getByRole('link', { name: 'Equipas' })).toHaveAttribute('href', '/teams');
+    expect(screen.getByRole('link', { name: 'Pistas' })).toHaveAttribute('href', '/tracks');
+    expect(screen.getByRole('link', { name: 'Simulações' })).toHaveAttribute('href', '/simulations');
+    expect(screen.getByRole('link', { name: 'Dados' })).toHaveAttribute('href', '/data');
+    expect(screen.getByRole('link', { name: 'Análises' })).toHaveAttribute('href', '/analysis');
+    expect(screen.getByRole('link', { name: 'Configurações' })).toHaveAttribute('href', '/settings');
+  });
+});

--- a/f1-predictor-full/tests/setupTests.ts
+++ b/f1-predictor-full/tests/setupTests.ts
@@ -1,0 +1,27 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { vi } from 'vitest';
+
+type LinkProps = {
+  href: string | { pathname?: string };
+  children: React.ReactNode;
+  [key: string]: unknown;
+};
+
+const MockLink = React.forwardRef<HTMLAnchorElement, LinkProps>(
+  ({ href, children, ...rest }, ref) =>
+    React.createElement(
+      'a',
+      {
+        ...rest,
+        ref,
+        href: typeof href === 'string' ? href : href?.pathname ?? '',
+      },
+      children,
+    ),
+);
+
+vi.mock('next/link', () => ({
+  __esModule: true,
+  default: MockLink,
+}));

--- a/f1-predictor-full/tests/simulationStore.test.ts
+++ b/f1-predictor-full/tests/simulationStore.test.ts
@@ -1,0 +1,106 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useSimulationStore } from '../stores/simulationStore';
+
+const resetStore = () => {
+  useSimulationStore.persist.clearStorage();
+  useSimulationStore.setState({
+    currentRun: null,
+    isRunning: false,
+    isFinished: false,
+    history: [],
+    activeDrivers: [],
+  });
+};
+
+beforeEach(() => {
+  resetStore();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  resetStore();
+});
+
+describe('useSimulationStore', () => {
+  it('starts and completes a run while recording history', () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1700000000000);
+    const { result } = renderHook(() => useSimulationStore());
+
+    act(() => {
+      result.current.startRun();
+    });
+
+    expect(result.current.isRunning).toBe(true);
+    expect(result.current.isFinished).toBe(false);
+    expect(result.current.currentRun).toEqual({ id: 1700000000000 });
+
+    act(() => {
+      result.current.endRun();
+    });
+
+    expect(result.current.isRunning).toBe(false);
+    expect(result.current.isFinished).toBe(true);
+    expect(result.current.history).toEqual([{ id: 1700000000000 }]);
+
+    nowSpy.mockRestore();
+  });
+
+  it('toggles drivers and their strengths and weaknesses', () => {
+    const { result } = renderHook(() => useSimulationStore());
+
+    act(() => {
+      result.current.toggleDriver('Max Verstappen', 'Red Bull');
+    });
+
+    expect(result.current.activeDrivers).toHaveLength(1);
+    expect(result.current.activeDrivers[0]).toMatchObject({
+      name: 'Max Verstappen',
+      team: 'Red Bull',
+      strengthsEnabled: [],
+      weaknessesEnabled: [],
+    });
+
+    act(() => {
+      result.current.toggleStrength('Max Verstappen', 'qualifying');
+      result.current.toggleWeakness('Max Verstappen', 'reliability');
+    });
+
+    expect(result.current.activeDrivers[0].strengthsEnabled).toContain('qualifying');
+    expect(result.current.activeDrivers[0].weaknessesEnabled).toContain('reliability');
+
+    act(() => {
+      result.current.toggleStrength('Max Verstappen', 'qualifying');
+      result.current.toggleWeakness('Max Verstappen', 'reliability');
+      result.current.toggleDriver('Max Verstappen', 'Red Bull');
+    });
+
+    expect(result.current.activeDrivers).toHaveLength(0);
+  });
+
+  it('resets the entire run state', () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(42);
+    const { result } = renderHook(() => useSimulationStore());
+
+    act(() => {
+      result.current.startRun();
+      result.current.endRun();
+      result.current.toggleDriver('Lewis Hamilton', 'Mercedes');
+    });
+
+    expect(result.current.history).toHaveLength(1);
+    expect(result.current.activeDrivers).toHaveLength(1);
+
+    act(() => {
+      result.current.resetAll();
+    });
+
+    expect(result.current.history).toHaveLength(0);
+    expect(result.current.currentRun).toBeNull();
+    expect(result.current.isRunning).toBe(false);
+    expect(result.current.isFinished).toBe(false);
+    expect(result.current.activeDrivers).toHaveLength(0);
+
+    nowSpy.mockRestore();
+  });
+});

--- a/f1-predictor-full/vitest.config.ts
+++ b/f1-predictor-full/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./tests/setupTests.ts'],
+    include: ['tests/**/*.{test,spec}.{ts,tsx}'],
+    globals: true,
+  },
+});


### PR DESCRIPTION
## Summary
- configure Vitest with a jsdom environment and shared setup to support Testing Library and Next.js Link
- add coverage for simulation store behaviour and navbar navigation rendering using Vitest
- refactor the Navbar component to use a link configuration array for readability and testability

## Testing
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68c9597b19b8832b8a50ccef2331cfa1