### PR TITLE
Add global Navbar to root layout

### DIFF
--- a/f1-predictor-full/app/layout.tsx
+++ b/f1-predictor-full/app/layout.tsx
@@ -1,3 +1,5 @@
+import Navbar from "components/Navbar";
+
 export default function RootLayout({
   children,
 }: {
@@ -5,7 +7,10 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className="bg-dark text-white min-h-screen">{children}</body>
+      <body className="bg-dark text-white min-h-screen">
+        <Navbar />
+        {children}
+      </body>
     </html>
   );
 }


### PR DESCRIPTION
## Summary
- import the shared Navbar component into the root layout
- render the Navbar ahead of page content so it appears on all pages

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c95f5f05c4832bb99dc86ec54ebf30