### PR TITLE
Prune navbar entries and scaffold active pages

### DIFF
--- a/f1-predictor-full/app/dashboard/page.tsx
+++ b/f1-predictor-full/app/dashboard/page.tsx
@@ -1,0 +1,11 @@
+export default function DashboardPage() {
+  return (
+    <main className="p-6 space-y-4">
+      <h1 className="text-3xl font-display font-bold">Dashboard</h1>
+      <p className="text-base text-zinc-300">
+        O painel de controlo do F1 Nexus ficará disponível aqui em breve, com uma
+        visão geral dos principais indicadores da temporada.
+      </p>
+    </main>
+  );
+}

--- a/f1-predictor-full/app/data/page.tsx
+++ b/f1-predictor-full/app/data/page.tsx
@@ -1,0 +1,11 @@
+export default function DataPage() {
+  return (
+    <main className="p-6 space-y-4">
+      <h1 className="text-3xl font-display font-bold">Dados</h1>
+      <p className="text-base text-zinc-300">
+        Aqui ficará disponível a gestão dos conjuntos de dados, modelos e
+        templates utilizados pelo ecossistema F1 Nexus.
+      </p>
+    </main>
+  );
+}

--- a/f1-predictor-full/app/simulations/page.tsx
+++ b/f1-predictor-full/app/simulations/page.tsx
@@ -1,0 +1,11 @@
+export default function SimulationsPage() {
+  return (
+    <main className="p-6 space-y-4">
+      <h1 className="text-3xl font-display font-bold">Simulações</h1>
+      <p className="text-base text-zinc-300">
+        Esta área vai permitir configurar cenários e acompanhar o histórico das
+        corridas simuladas assim que os módulos estiverem prontos.
+      </p>
+    </main>
+  );
+}

--- a/f1-predictor-full/components/Navbar.tsx
+++ b/f1-predictor-full/components/Navbar.tsx
@@ -3,13 +3,8 @@ export default function Navbar() {
   return (
     <nav className="flex gap-4 p-4 bg-primary font-bold">
       <Link href="/dashboard">Dashboard</Link>
-      <Link href="/drivers">Pilotos</Link>
-      <Link href="/teams">Equipas</Link>
-      <Link href="/tracks">Pistas</Link>
       <Link href="/simulations">Simulações</Link>
       <Link href="/data">Dados</Link>
-      <Link href="/analysis">Análises</Link>
-      <Link href="/settings">Configurações</Link>
     </nav>
   );
 }


### PR DESCRIPTION
## Summary
- remove obsolete navigation links from the navbar so it only highlights active sections
- add placeholder pages for the dashboard, simulations and data routes so planned pages resolve

## Testing
- npm test -- --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68c95f5d4bb8832b88432375eb024675