### PR TITLE
Fix rain probability fallback when race column missing

### DIFF
--- a/f1-predictor-full/etl/etl.py
+++ b/f1-predictor-full/etl/etl.py
@@ -554,6 +554,7 @@ def compute_rain_probability(
 
     if weather_df is not None:
         weather_df = weather_df.copy()
+        name_col: Optional[str] = None
         candidate_name_cols = [
             c
             for c in weather_df.columns
@@ -581,7 +582,8 @@ def compute_rain_probability(
                 numeric_cols = [
                     c
                     for c in matches.columns
-                    if pd.api.types.is_numeric_dtype(matches[c]) and c != name_col
+                    if pd.api.types.is_numeric_dtype(matches[c])
+                    and (name_col is None or c != name_col)
                 ]
                 if numeric_cols:
                     prob_col = numeric_cols[0]

--- a/tests/test_etl_rain_probability.py
+++ b/tests/test_etl_rain_probability.py
@@ -1,0 +1,34 @@
+import sys
+import unittest
+from pathlib import Path
+
+import pandas as pd
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+ETL_DIR = PROJECT_ROOT / "f1-predictor-full" / "etl"
+if str(ETL_DIR) not in sys.path:
+    sys.path.insert(0, str(ETL_DIR))
+
+from etl import compute_rain_probability
+
+
+class TestComputeRainProbability(unittest.TestCase):
+    def test_without_race_name_column_uses_numeric_fallback(self) -> None:
+        base = pd.DataFrame({"driverId": [1]})
+        weather_df = pd.DataFrame(
+            {
+                "chance_value": [70],
+                "conditions": ["cloudy"],
+            }
+        )
+        scraper_tables = {"weather": weather_df}
+        race_record = pd.Series({"name": "Sample GP"})
+
+        result = compute_rain_probability(base.copy(), scraper_tables, race_record)
+
+        self.assertIn("rain_prob", result.columns)
+        self.assertAlmostEqual(result.loc[0, "rain_prob"], 0.7)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- initialize the weather name column placeholder and guard numeric fallback selection when a race label is absent
- add a unit test exercising compute_rain_probability with weather data that lacks a race name column

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c99c135c78832bb30993644f460cde