### PR TITLE
Configure Vitest and add frontend tests

### DIFF
--- a/f1-predictor-full/next-env.d.ts
+++ b/f1-predictor-full/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/f1-predictor-full/tests/Navbar.test.tsx
+++ b/f1-predictor-full/tests/Navbar.test.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import Navbar from "../components/Navbar";
+
+describe("Navbar", () => {
+  it("renders primary navigation links", () => {
+    render(<Navbar />);
+
+    const dashboardLink = screen.getByRole("link", { name: /dashboard/i });
+    const simulationsLink = screen.getByRole("link", { name: /simulações/i });
+    const dataLink = screen.getByRole("link", { name: /dados/i });
+
+    expect(dashboardLink).toHaveAttribute("href", "/dashboard");
+    expect(simulationsLink).toHaveAttribute("href", "/simulations");
+    expect(dataLink).toHaveAttribute("href", "/data");
+  });
+});

--- a/f1-predictor-full/tests/simulationStore.test.ts
+++ b/f1-predictor-full/tests/simulationStore.test.ts
@@ -1,0 +1,81 @@
+import { act } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useSimulationStore } from "../stores/simulationStore";
+
+describe("useSimulationStore", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    const { resetAll } = useSimulationStore.getState();
+    act(() => {
+      resetAll();
+    });
+  });
+
+  it("manages the lifecycle of a simulation run", () => {
+    const { startRun } = useSimulationStore.getState();
+
+    act(() => {
+      startRun();
+    });
+
+    const afterStart = useSimulationStore.getState();
+    expect(afterStart.isRunning).toBe(true);
+    expect(afterStart.currentRun).not.toBeNull();
+    expect(afterStart.isFinished).toBe(false);
+
+    const initialRunId = afterStart.currentRun?.id;
+    expect(typeof initialRunId).toBe("number");
+
+    act(() => {
+      useSimulationStore.getState().endRun();
+    });
+
+    const afterEnd = useSimulationStore.getState();
+    expect(afterEnd.isRunning).toBe(false);
+    expect(afterEnd.isFinished).toBe(true);
+    expect(afterEnd.currentRun).toBeNull();
+    expect(afterEnd.history).toHaveLength(1);
+    expect(afterEnd.history[0]?.id).toBe(initialRunId);
+  });
+
+  it("tracks driver roster and attribute toggles", () => {
+    act(() => {
+      useSimulationStore.getState().toggleDriver("Lando Norris", "McLaren");
+    });
+
+    let state = useSimulationStore.getState();
+    expect(state.activeDrivers).toHaveLength(1);
+    expect(state.activeDrivers[0]).toMatchObject({
+      name: "Lando Norris",
+      team: "McLaren",
+      strengthsEnabled: [],
+      weaknessesEnabled: [],
+    });
+
+    act(() => {
+      useSimulationStore.getState().toggleStrength("Lando Norris", "qualifying");
+      useSimulationStore.getState().toggleWeakness("Lando Norris", "tire-wear");
+    });
+
+    state = useSimulationStore.getState();
+    expect(state.activeDrivers[0]?.strengthsEnabled).toContain("qualifying");
+    expect(state.activeDrivers[0]?.weaknessesEnabled).toContain("tire-wear");
+
+    act(() => {
+      useSimulationStore.getState().toggleStrength("Lando Norris", "qualifying");
+      useSimulationStore.getState().toggleWeakness("Lando Norris", "tire-wear");
+    });
+
+    state = useSimulationStore.getState();
+    expect(state.activeDrivers[0]?.strengthsEnabled).not.toContain("qualifying");
+    expect(state.activeDrivers[0]?.weaknessesEnabled).not.toContain("tire-wear");
+
+    act(() => {
+      useSimulationStore.getState().resetDrivers();
+    });
+
+    state = useSimulationStore.getState();
+    expect(state.activeDrivers).toHaveLength(0);
+  });
+});

--- a/f1-predictor-full/tsconfig.json
+++ b/f1-predictor-full/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -13,9 +17,28 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "types": ["vitest/globals", "@testing-library/jest-dom", "node"],
-    "baseUrl": "."
+    "types": [
+      "vitest/globals",
+      "@testing-library/jest-dom",
+      "node"
+    ],
+    "baseUrl": ".",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "app/**/*", "components/**/*", "stores/**/*", "tests/**/*", "styles/**/*"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "app/**/*",
+    "components/**/*",
+    "stores/**/*",
+    "tests/**/*",
+    "styles/**/*",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/f1-predictor-full/vitest.config.ts
+++ b/f1-predictor-full/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "jsdom",
+    setupFiles: "./vitest.setup.ts",
+    include: ["tests/**/*.{test,spec}.{ts,tsx}", "**/__tests__/**/*.{ts,tsx}"],
+    css: true,
+    environmentOptions: {
+      jsdom: {
+        url: "http://localhost",
+      },
+    },
+  },
+  esbuild: {
+    jsx: "automatic",
+    jsxImportSource: "react",
+  },
+});

--- a/f1-predictor-full/vitest.setup.ts
+++ b/f1-predictor-full/vitest.setup.ts
@@ -1,0 +1,13 @@
+import { createElement, type AnchorHTMLAttributes, type DetailedHTMLProps, type PropsWithChildren } from "react";
+import "@testing-library/jest-dom/vitest";
+
+type AnchorProps = DetailedHTMLProps<
+  AnchorHTMLAttributes<HTMLAnchorElement>,
+  HTMLAnchorElement
+> & { href: string };
+
+vi.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, href, ...props }: PropsWithChildren<AnchorProps>) =>
+    createElement("a", { ...props, href }, children),
+}));


### PR DESCRIPTION
## Summary
- configure Vitest for the Next.js workspace with jsdom, setup mocks, and React JSX support
- add regression coverage for the Zustand simulation store and navbar navigation links
- commit the generated Next.js type references so TypeScript sees framework types

## Testing
- `pytest`
- `npm test -- --run`
- `CI=1 npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c9a749725c832bbd88761b53facbb7