### PR TITLE
Include Next.js route type definitions

### DIFF
--- a/f1-predictor-full/tsconfig.json
+++ b/f1-predictor-full/tsconfig.json
@@ -31,12 +31,12 @@
   },
   "include": [
     "next-env.d.ts",
+    ".next/types/**/*.ts",
     "app/**/*",
     "components/**/*",
     "stores/**/*",
     "tests/**/*",
-    "styles/**/*",
-    ".next/types/**/*.ts"
+    "styles/**/*"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
## Summary
- ensure the Next.js generated route types directory is included in the TypeScript configuration for the app

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9e159f3b0832b99d49d7905073959